### PR TITLE
Add installation for benchmarking

### DIFF
--- a/tools/setup_kube.sh
+++ b/tools/setup_kube.sh
@@ -32,6 +32,8 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
 sudo apt install -y docker.io
 # Docker without sudo
 sudo usermod -aG docker $USER
+# Login to docker
+newgrp docker
 # Kubectl
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 sudo touch /etc/apt/sources.list.d/kubernetes.list

--- a/tools/setup_kube.sh
+++ b/tools/setup_kube.sh
@@ -26,14 +26,11 @@ sudo install minikube-darwin-amd64 /usr/local/bin/minikube
 rm -rf minikube-darwin-amd64
 # Need to use docker because we are in a VM
 minikube config set driver hyperkit
-
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
 # Docker
 sudo apt install -y docker.io
 # Docker without sudo
 sudo usermod -aG docker $USER
-# Login to docker
-newgrp docker
 # Kubectl
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 sudo touch /etc/apt/sources.list.d/kubernetes.list
@@ -69,5 +66,8 @@ make -C tools/parallel_curl/
 
 # Remaining core deps
 ${FILE_DIR}/setup_sim.sh
+
+# Login to docker after installation
+newgrp docker
 
 echo "Done with Kubernetes setup."

--- a/tools/setup_sim.sh
+++ b/tools/setup_sim.sh
@@ -26,4 +26,6 @@ pip3 install --user pytest
 # Install requests for API requests (needed here because of imports)
 pip3 install --user requests
 
+# Install pandas and seaborn for benchmarking
+pip3 install --user seaborn pandas
 echo "Done with simulator setup."


### PR DESCRIPTION
# Description
- When I initially install and run `./kube_env .py--setup` on Ubuntu VM, it exits with error `Got permission denied`. `Need to newgrp docker` after installing to run docker.
- Add installation for pandas and seaborn for benchmarking.