### PR TITLE
Refactoring benchmark script

### DIFF
--- a/kubernetes_env/benchmark/benchmark.py
+++ b/kubernetes_env/benchmark/benchmark.py
@@ -92,7 +92,7 @@ def run_fortio(url, platform, threads, qps, run_time, file_name):
     output_file = str(DATA_DIR.joinpath(f"{file_name}.json"))
     fortio_dir = str(FORTIO_DIR)
     cmd = f"{fortio_dir} "
-    cmd += f"load -c {threads} -qps {qps} -jitter -t {run_time}s -json {output_file} "
+    cmd += f"load -c {threads} -qps {qps} -timeout 50s -t {run_time}s -json {output_file} "
     cmd += f"{url}"
     with open(output_file, "w") as f:
         fortio_res = util.exec_process(cmd,
@@ -234,18 +234,18 @@ if __name__ == '__main__':
                         "--threads",
                         dest="threads",
                         type=int,
-                        default=4,
+                        default=2,
                         help="Number of threads")
     parser.add_argument("-qps",
                         dest="qps",
                         type=int,
-                        default=50,
+                        default=10,
                         help="Query per second")
     parser.add_argument("-t",
                         "--time",
                         dest="time",
                         type=int,
-                        default=30,
+                        default=120,
                         help="Time for fortio")
     parser.add_argument("-cu",
                         "--use-custom",

--- a/kubernetes_env/benchmark/benchmark.py
+++ b/kubernetes_env/benchmark/benchmark.py
@@ -68,7 +68,6 @@ def transform_fortio_data(filters):
     return dfs, title
 
 
-
 def plot(dfs, filters, title, plot_name, fortio=True):
     timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(time.time()))
     plot_name += f" {timestamp}"
@@ -78,11 +77,11 @@ def plot(dfs, filters, title, plot_name, fortio=True):
         plt.legend(labels=filters)
         plt.title(f"Fortio: {title}")
     else:
-        fig, (ax1,ax2) = plt.subplots(1,2, figsize=(18,6))
-        dplot = sns.ecdfplot(dfs, ax= ax1)
+        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(18, 6))
+        dplot = sns.ecdfplot(dfs, ax=ax1)
         dplot.set(xlabel="Latency (ms)", ylabel="Percentiles")
-        hplot = sns.histplot(dfs, ax= ax2)
-        hplot.set(xlabel="Latency (ms)", ylabel="Count")     
+        hplot = sns.histplot(dfs, ax=ax2)
+        hplot.set(xlabel="Latency (ms)", ylabel="Count")
     util.check_dir(GRAPHS_DIR)
     plt.savefig(f"{GRAPHS_DIR}/{plot_name}.png")
     log.info("Finished plotting. Check out the graphs directory!")
@@ -104,8 +103,10 @@ def run_fortio(url, platform, request_type, threads, qps, run_time, file_name):
                                        stderr=subprocess.PIPE)
         return fortio_res
 
+
 def do_burst(url, platform, request_type, threads, qps, run_time):
     output = []
+
     def get_request(_):
         try:
             # What should timeout be?
@@ -149,7 +150,7 @@ def start_benchmark(filter_dirs, platform, threads, qps, run_time, **kwargs):
     log.info("Gateway URL: %s", url)
     results = []
     filters = []
-    if kwargs.get("no_filter"):
+    if kwargs.get("no_filter") == "ON":
         filter_dirs.append("no_filter")
         filters.append("no_filter")
     custom = kwargs.get("custom")
@@ -193,7 +194,8 @@ def start_benchmark(filter_dirs, platform, threads, qps, run_time, **kwargs):
                 return util.EXIT_FAILURE
         else:
             log.info("Generating load...")
-            burst_res = do_burst(url, platform, request, threads, qps, run_time)
+            burst_res = do_burst(url, platform, request, threads, qps,
+                                 run_time)
             results.append(burst_res)
 
     if custom == "fortio":
@@ -207,7 +209,16 @@ def start_benchmark(filter_dirs, platform, threads, qps, run_time, **kwargs):
 
 
 def main(args):
-    return start_benchmark(args.filter_dirs, args.platform, args.threads, args.qps, args.time, no_filter=args.nf, output=args.output, subpath=args.subpath, request=args.request, custom=args.custom.lower())
+    return start_benchmark(args.filter_dirs,
+                           args.platform,
+                           args.threads,
+                           args.qps,
+                           args.time,
+                           no_filter=args.nf,
+                           output=args.output,
+                           subpath=args.subpath,
+                           request=args.request,
+                           custom=args.custom.lower())
 
 
 if __name__ == '__main__':
@@ -269,7 +280,7 @@ if __name__ == '__main__':
     parser.add_argument("-nf",
                         "--no-filter",
                         dest="nf",
-                        default=True,
+                        default="ON",
                         help="Benchmark with no filter")
     parser.add_argument("-o",
                         "--output",

--- a/kubernetes_env/benchmark/rs-empty-filter/filter.rs
+++ b/kubernetes_env/benchmark/rs-empty-filter/filter.rs
@@ -71,6 +71,7 @@ impl RootContext for HttpHeadersRoot {
     }
 }
 
+#[allow(dead_code)]
 struct HttpHeaders {
     context_id: u32,
     workload_name: String,
@@ -79,7 +80,7 @@ struct HttpHeaders {
 impl Context for HttpHeaders {}
 
 impl HttpContext for HttpHeaders {
-    fn on_http_request_headers(&mut self, num_headers: usize) -> Action {
+    fn on_http_request_headers(&mut self, _num_headers: usize) -> Action {
         let direction = self.get_traffic_direction();
         if direction == TrafficDirection::Inbound {
             self.on_http_request_headers_inbound();
@@ -92,7 +93,7 @@ impl HttpContext for HttpHeaders {
         Action::Continue
     }
 
-    fn on_http_response_headers(&mut self, num_headers: usize) -> Action {
+    fn on_http_response_headers(&mut self, _num_headers: usize) -> Action {
         let direction = self.get_traffic_direction();
         if direction == TrafficDirection::Inbound {
             self.on_http_response_headers_inbound();

--- a/kubernetes_env/benchmark/rs-loop-filter/filter.rs
+++ b/kubernetes_env/benchmark/rs-loop-filter/filter.rs
@@ -71,6 +71,7 @@ impl RootContext for HttpHeadersRoot {
     }
 }
 
+#[allow(dead_code)]
 struct HttpHeaders {
     context_id: u32,
     workload_name: String,
@@ -79,8 +80,8 @@ struct HttpHeaders {
 impl Context for HttpHeaders {}
 
 impl HttpContext for HttpHeaders {
-    fn on_http_request_headers(&mut self, num_headers: usize) -> Action {
-        let mut direction = self.get_traffic_direction();
+    fn on_http_request_headers(&mut self, _num_headers: usize) -> Action {
+        let direction = self.get_traffic_direction();
         if direction == TrafficDirection::Inbound {
             self.on_http_request_headers_inbound();
         } else if direction == TrafficDirection::Outbound {
@@ -92,8 +93,8 @@ impl HttpContext for HttpHeaders {
         Action::Continue
     }
 
-    fn on_http_response_headers(&mut self, num_headers: usize) -> Action {
-        let mut direction = self.get_traffic_direction();
+    fn on_http_response_headers(&mut self, _num_headers: usize) -> Action {
+        let direction = self.get_traffic_direction();
         if direction == TrafficDirection::Inbound {
             self.on_http_response_headers_inbound();
         } else if direction == TrafficDirection::Outbound {
@@ -109,7 +110,7 @@ impl HttpHeaders {
     // Retrieves the traffic direction from the configuration context.
     fn get_traffic_direction(&self) -> TrafficDirection {
         if let Some(direction_bytes) = self.get_property(vec!["listener_direction"]) {
-            let mut cast_bytes = <[u8; 8]>::try_from(direction_bytes);
+            let cast_bytes = <[u8; 8]>::try_from(direction_bytes);
             match cast_bytes {
                 Ok(byte_array) => return i64::from_ne_bytes(byte_array).into(),
                 Err(_e) => return 0i64.into(),
@@ -124,11 +125,11 @@ impl HttpHeaders {
        let mut c = 0.0;
        let mut d = 0.0;
        let mut e = 0.0;
-       for i in 0..1000 {
+       for _i in 0..1000 {
           c += a;
           d += b;
           e += a;
-          log::warn!("Current value for c: {} , d: {}, e: {}", c, d, a);
+          log::warn!("Current value for c: {} , d: {}, e: {}", c, d, e);
        }
        log::warn!("Traversed."); 
     }
@@ -138,11 +139,11 @@ impl HttpHeaders {
        let mut c = 0.0;
        let mut d = 0.0;
        let mut e = 0.0;
-       for i in 0..1000 {
+       for _i in 0..1000 {
           c += a;
           d += b;
           e += a;
-          log::warn!("Current value for c: {} , d: {}, e: {}", c, d, a);
+          log::warn!("Current value for c: {} , d: {}, e: {}", c, d, e);
        }
        log::warn!("Traversed."); 
     }
@@ -153,11 +154,11 @@ impl HttpHeaders {
        let mut c = 0.0;
        let mut d = 0.0;
        let mut e = 0.0;
-       for i in 0..1000 {
+       for _i in 0..1000 {
           c += a;
           d += b;
           e += a;
-          log::warn!("Current value for c: {} , d: {}, e: {}", c, d, a);
+          log::warn!("Current value for c: {} , d: {}, e: {}", c, d, e);
        }
        log::warn!("Traversed."); 
     }
@@ -168,11 +169,11 @@ impl HttpHeaders {
        let mut c = 0.0;
        let mut d = 0.0;
        let mut e = 0.0;
-       for i in 0..1000 {
+       for _i in 0..1000 {
           c += a;
           d += b;
           e += a;
-          log::warn!("Current value for c: {} , d: {}, e: {}", c, d, a);
+          log::warn!("Current value for c: {} , d: {}, e: {}", c, d, e);
        }
        log::warn!("Traversed."); 
     }

--- a/kubernetes_env/kube_env.py
+++ b/kubernetes_env/kube_env.py
@@ -516,7 +516,7 @@ if __name__ == '__main__':
                         dest="application",
                         default="BK",
                         choices=["BK", "HR", "OB", "TT"],
-                        help="Which platform to run the scripts on."
+                        help="Which application to deploy."
                         "BK is bookinfo, HR is hotel reservation, and OB is online boutique")
     parser.add_argument("-m",
                         "--multi-zonal",


### PR DESCRIPTION
# Description
- Reduce `qps` and thread counts for fortio and load generator to collect enough data.
- Adding `-output`, `request-type` and `no-filter` flag to indicate output file name, GET or POST request and including benchmarking with no filter or not in the script.